### PR TITLE
Fix Body As Array

### DIFF
--- a/src/Extracting/Generator.php
+++ b/src/Extracting/Generator.php
@@ -239,6 +239,6 @@ class Generator
             $paramName = str_replace(['][', '[', ']', '..'], ['.', '.', '', '.*.'], $paramName);
         }
         // Then generate a sample item for the dot notation
-        Arr::set($values, str_replace('.*', '.0', $paramName), $paramExample);
+        Arr::set($values, str_replace(['.*', '*.'], ['.0','0.'], $paramName), $paramExample);
     }
 }

--- a/tests/Fixtures/TestController.php
+++ b/tests/Fixtures/TestController.php
@@ -89,6 +89,20 @@ class TestController extends Controller
         return '';
     }
 
+    /**
+     * Endpoint with body parameters as array.
+     *
+     * @bodyParam *.first_name string The first name of the user. Example: John
+     * @bodyParam *.last_name string The last name of the user. Example: Doe
+     * @bodyParam *.contacts.*.first_name string The first name of the contact. Example: John
+     * @bodyParam *.contacts.*.last_name string The last name of the contact. Example: Doe
+     * @bodyParam *.roles.* string The name of the role. Example: Admin
+     */
+    public function withBodyParametersAsArray()
+    {
+        return '';
+    }
+
     public function withFormRequestParameter(TestRequest $request)
     {
         return '';

--- a/tests/Unit/GeneratorTestCase.php
+++ b/tests/Unit/GeneratorTestCase.php
@@ -172,6 +172,64 @@ abstract class GeneratorTestCase extends TestCase
     }
 
     /** @test */
+    public function can_parse_body_parameters_as_array()
+    {
+        $route = $this->createRoute('GET', '/api/test', 'withBodyParametersAsArray');
+        $generator = $this->generator->processRoute($route);
+        $bodyParameters = $generator['bodyParameters'];
+        $cleanBodyParameters = $generator['cleanBodyParameters'];
+
+        $this->assertArraySubset([
+            '*.first_name' => [
+                'type' => 'string',
+                'description' => 'The first name of the user.',
+                'required' => false,
+                'value' => 'John',
+            ],
+            '*.last_name' => [
+                'type' => 'string',
+                'description' => 'The last name of the user.',
+                'required' => false,
+                'value' => 'Doe',
+            ],
+            '*.contacts.*.first_name' => [
+                'type' => 'string',
+                'description' => 'The first name of the contact.',
+                'required' => false,
+                'value' => 'John',
+            ],
+            '*.contacts.*.last_name' => [
+                'type' => 'string',
+                'description' => 'The last name of the contact.',
+                'required' => false,
+                'value' => 'Doe',
+            ],
+            '*.roles.*' => [
+                'type' => 'string',
+                'description' => 'The name of the role.',
+                'required' => false,
+                'value' => 'Admin',
+            ],
+        ], $bodyParameters);
+
+        $this->assertArraySubset([
+            [
+               'first_name' => 'John',
+               'last_name' => 'Doe',
+               'contacts' => [
+                    [
+                        'first_name' => 'John',
+                        'last_name' => 'Doe',
+                    ]
+                ],
+                'roles' => [
+                    'Admin'
+                ]
+            ]
+        ], $cleanBodyParameters);
+    }
+
+    /** @test */
     public function it_ignores_non_commented_form_request()
     {
         $route = $this->createRoute('GET', '/api/test', 'withNonCommentedFormRequestParameter');


### PR DESCRIPTION
Currently, if an array of objects is sent in the body, when the example is created the result will be saved in a '*' key because only '. *' is replaced by '.0', if the bodyParam name starts with '*.' This should indicate that the body itself is an array of objects but not an object with a key '*',  
replacement order is important